### PR TITLE
Add Supabase config generation and connection indicator

### DIFF
--- a/generate-config.js
+++ b/generate-config.js
@@ -1,0 +1,14 @@
+import { writeFileSync } from 'fs';
+
+const config = `window.__APP_CONFIG__ = {
+  SUPABASE_URL: "${process.env.SUPABASE_URL || ''}",
+  SUPABASE_ANON_KEY: "${process.env.SUPABASE_ANON_KEY || ''}",
+  USE_MOCK: false
+};\n`;
+
+try {
+  writeFileSync('config.js', config);
+  console.log('config.js generated');
+} catch (err) {
+  console.error('Failed to write config.js', err);
+}

--- a/index.html
+++ b/index.html
@@ -88,6 +88,9 @@
 
   <input type="file" id="import-file-input" accept=".json" class="hidden" />
 
+  <!-- Indicador de conexión a Supabase (esquina inferior izquierda) -->
+  <div id="db-connection-indicator" class="fixed bottom-1 left-1 w-3 h-3 rounded-full bg-red-500 opacity-40 pointer-events-none"></div>
+
   <!-- 1) Config de runtime generada en el deploy con repo secrets -->
   <script src="config.js"></script>
 

--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ const closeSidebarBtn = document.getElementById('close-sidebar-btn');
 const sidebarOverlay = document.getElementById('sidebar-overlay');
 const mobileHeaderTitle = document.getElementById('mobile-header-title');
 const themeSwitcherBtns = document.querySelectorAll('.theme-switcher');
+const dbIndicator = document.getElementById('db-connection-indicator');
 
 function render() {
     mainContent.innerHTML = '';
@@ -56,6 +57,13 @@ function updateNavButtons() {
         btn.classList.toggle('hover:bg-gray-200', !isActive);
         btn.classList.toggle('dark:hover:bg-gray-700', !isActive);
     });
+}
+
+async function updateDbIndicator() {
+    if (!dbIndicator) return;
+    const ok = await testConnection();
+    dbIndicator.classList.toggle('bg-green-500', ok);
+    dbIndicator.classList.toggle('bg-red-500', !ok);
 }
 
 
@@ -187,6 +195,9 @@ async function init() {
     loadState();
     render();
     updateNavButtons();
+    // Actualiza el indicador de conexión y vuelve a chequear periódicamente
+    updateDbIndicator();
+    setInterval(updateDbIndicator, 30000);
     
     navButtons.forEach(btn => {
         btn.addEventListener('click', () => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Teacher's Dashboard Application with Supabase persistence",
   "type": "module",
   "scripts": {
-    "dev": "python3 -m http.server 8080",
+    "dev": "node generate-config.js && python3 -m http.server 8080",
     "build": "echo 'No build step required for this project'"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- generate `config.js` from environment variables for local development
- add hidden Supabase connection indicator and periodic health checks
- update dev script to build config and serve app

## Testing
- `npm run build`
- `curl -I http://localhost:8080/`
- `curl -s -H "apikey: $SUPABASE_ANON_KEY" -H "Authorization: Bearer $SUPABASE_ANON_KEY" "https://kdxlawphtdbfiudinywo.supabase.co/rest/v1/activities?select=*" | head`


------
https://chatgpt.com/codex/tasks/task_e_68a43cd852588326ae53c1a1b0b22ea9