### PR TITLE
feat: check Supabase connection on startup

### DIFF
--- a/main.js
+++ b/main.js
@@ -190,6 +190,14 @@ async function init() {
         `;
         document.head.appendChild(script);
     }
+
+    const conn = await testConnection();
+    if (conn.ok) {
+        console.log('☁️ Supabase conectado. Modo nube activo.');
+    } else {
+        console.error('⚠️ No se pudo conectar a Supabase:', conn.error);
+    }
+    state.isOnline = conn.ok;
     
     const savedTheme = localStorage.getItem('theme') || 'system';
     setTheme(savedTheme);

--- a/supabase.js
+++ b/supabase.js
@@ -51,19 +51,19 @@ export { supabase };
 
 // Pequeño sanity check
 export async function testConnection() {
-  if (!supabase) return false;
+  if (!supabase) {
+    return { ok: false, error: new Error("Supabase no está configurado") };
+  }
   try {
     // Cuenta filas sin traer datos
     const { error, count } = await supabase
       .from("activities")
       .select("*", { count: "exact", head: true });
     if (error) {
-      console.error("Supabase error:", error);
-      return false;
+      return { ok: false, error };
     }
-    return typeof count === "number";
+    return { ok: typeof count === "number" };
   } catch (e) {
-    console.error("Connection test failed:", e);
-    return false;
+    return { ok: false, error: e };
   }
 }


### PR DESCRIPTION
## Summary
- validate Supabase credentials on startup and warn if unavailable
- return error details from Supabase connection test

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aadb921d8c8326ab6b67ceb55ac058