### PR TITLE
feat: check Supabase connection on startup

### DIFF
--- a/main.js
+++ b/main.js
@@ -190,6 +190,14 @@ async function init() {
         `;
         document.head.appendChild(script);
     }
+
+    const conn = await testConnection();
+    if (conn.ok) {
+        console.log('☁️ Supabase conectado. Modo nube activo.');
+    } else {
+        console.error('⚠️ No se pudo conectar a Supabase:', conn.error);
+    }
+    state.isOnline = conn.ok;
     
     const savedTheme = localStorage.getItem('theme') || 'system';
     setTheme(savedTheme);


### PR DESCRIPTION
## Summary
- validate Supabase credentials on startup and warn if unavailable
- return error details from Supabase connection test
- normalize missing SUPABASE_URL protocol and surface init errors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aadb921d8c8326ab6b67ceb55ac058