### PR TITLE
feat: show offline mode banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <div id="offline-banner" class="hidden bg-orange-600 text-white text-center py-2">
+    Trabajando sin conexión. Los cambios se guardarán localmente.
+  </div>
   <!-- Mobile Header -->
   <div class="sm:hidden bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-40">
     <div class="flex items-center justify-between px-4 py-3">

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 // main.js: El punto de entrada principal que une todo.
 
 import { supabase, testConnection } from './supabase.js';
-import { state, loadState } from './state.js';
+import { state, loadState, setOnlineStatus } from './state.js';
 import * as views from './views.js';
 import { actionHandlers } from './actions.js';
 import { initI18n, t } from './i18n.js';
@@ -14,6 +14,18 @@ const closeSidebarBtn = document.getElementById('close-sidebar-btn');
 const sidebarOverlay = document.getElementById('sidebar-overlay');
 const mobileHeaderTitle = document.getElementById('mobile-header-title');
 const themeSwitcherBtns = document.querySelectorAll('.theme-switcher');
+const offlineBanner = document.getElementById('offline-banner');
+
+function updateConnectionBanner() {
+    if (!offlineBanner) return;
+    if (state.isOnline) {
+        offlineBanner.classList.add('hidden');
+    } else {
+        offlineBanner.classList.remove('hidden');
+    }
+}
+
+document.addEventListener('online-status', updateConnectionBanner);
 
 function render() {
     mainContent.innerHTML = '';
@@ -197,7 +209,7 @@ async function init() {
     } else {
         console.error('⚠️ No se pudo conectar a Supabase:', conn.error);
     }
-    state.isOnline = conn.ok;
+    setOnlineStatus(conn.ok);
     
     const savedTheme = localStorage.getItem('theme') || 'system';
     setTheme(savedTheme);

--- a/state.js
+++ b/state.js
@@ -24,6 +24,11 @@ export const state = {
     isOnline: true,
 };
 
+export function setOnlineStatus(isOnline) {
+    state.isOnline = isOnline;
+    document.dispatchEvent(new CustomEvent('online-status', { detail: isOnline }));
+}
+
 export function getRandomPastelColor() {
     const usedColors = state.activities.map(a => a.color);
     const availableColors = pastelColors.filter(c => !usedColors.includes(c));
@@ -142,7 +147,7 @@ export async function saveState() {
             courseEndDate: state.courseEndDate,
         };
         localStorage.setItem('teacherDashboardData', JSON.stringify(dataToSave));
-        state.isOnline = false;
+        setOnlineStatus(false);
     }
 }
 
@@ -183,7 +188,7 @@ export async function loadState() {
         state.classEntries = classEntries || {};
         state.courseStartDate = courseSettings.courseStartDate || '';
         state.courseEndDate = courseSettings.courseEndDate || '';
-        state.isOnline = true;
+        setOnlineStatus(true);
         
         console.log('State loaded from Supabase successfully');
         
@@ -196,7 +201,7 @@ export async function loadState() {
         
     } catch (error) {
         console.error('Error loading from Supabase:', error);
-        state.isOnline = false;
+        setOnlineStatus(false);
         
         // Fallback: cargar desde localStorage
         await loadFromLocalStorage();


### PR DESCRIPTION
## Summary
- display banner when Supabase connection fails
- track connection state with `setOnlineStatus` and update banner on changes

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaf1a2a29483268e5889ec03a5de22