### PR TITLE
Fix dark mode and polish mobile UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,13 @@
   <title>Cuaderno del Profesor</title>
 
   <!-- UI libs -->
+  <script>
+    tailwind.config = { darkMode: 'class' };
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark' || (!storedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -13,7 +20,7 @@
   <script src="https://unpkg.com/lucide@latest"></script>
   <link rel="stylesheet" href="style.css" />
 </head>
-<body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+<body class="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-300">
   <div id="offline-banner" class="hidden bg-orange-600 text-white text-center py-2">
     Trabajando sin conexión. Los cambios se guardarán localmente.
   </div>
@@ -28,7 +35,7 @@
     </div>
   </div>
 
-  <div class="flex h-screen sm:h-auto">
+  <div class="flex min-h-screen sm:h-auto">
     <!-- Sidebar -->
     <div id="sidebar" class="fixed inset-y-0 left-0 z-50 w-64 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform -translate-x-full sm:relative sm:translate-x-0 transition-transform duration-300 ease-in-out">
       <div class="flex flex-col h-full">

--- a/main.js
+++ b/main.js
@@ -44,6 +44,14 @@ function render() {
     updateMobileHeader();
     lucide.createIcons();
     attachEventListeners();
+
+    const storageIndicator = document.getElementById('storage-mode-indicator');
+    if (storageIndicator && state.isOnline) {
+        setTimeout(() => {
+            storageIndicator.classList.add('opacity-0');
+            setTimeout(() => storageIndicator.classList.add('hidden'), 500);
+        }, 3000);
+    }
 }
 
 function updateMobileHeader() {

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
-body { 
-    font-family: 'Inter', sans-serif; 
+body {
+    font-family: 'Inter', sans-serif;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .animate-fade-in { 

--- a/views.js
+++ b/views.js
@@ -162,7 +162,7 @@ export function renderScheduleView() {
             </div>
             
             <!-- Storage Mode Indicator -->
-            <div id="storage-mode-indicator" class="mb-4 p-3 rounded-lg border-2 ${state.isOnline ? 'bg-green-50 border-green-200 dark:bg-green-900/20 dark:border-green-800' : 'bg-orange-50 border-orange-200 dark:bg-orange-900/20 dark:border-orange-800'}">
+            <div id="storage-mode-indicator" class="mb-4 p-3 rounded-lg border-2 transition-opacity duration-500 ${state.isOnline ? 'bg-green-50 border-green-200 dark:bg-green-900/20 dark:border-green-800' : 'bg-orange-50 border-orange-200 dark:bg-orange-900/20 dark:border-orange-800'}">
                 <div class="flex items-center justify-between">
                     <div class="flex items-center gap-3">
                         <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- enable Tailwind class-based dark mode and apply theme on load
- smooth theme transitions and mobile-friendly layout tweaks
- auto-hide cloud mode banner after three seconds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3b94c6e483269875ea5e6b4cdbf8